### PR TITLE
Fix ImportError for module bz2

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -25,6 +25,7 @@ RUN set -ex \
 		libssl-dev \
 		tcl-dev \
 		tk-dev \
+        	libbz2-dev \
 	' \
 	&& apt-get update \
 	&& apt-get install -y $buildDeps --no-install-recommends \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -25,6 +25,7 @@ RUN set -ex \
 		libssl-dev \
 		tcl-dev \
 		tk-dev \
+        	libbz2-dev \
 	' \
 	&& apt-get update \
 	&& apt-get install -y $buildDeps --no-install-recommends \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -25,6 +25,7 @@ RUN set -ex \
 		libssl-dev \
 		tcl-dev \
 		tk-dev \
+        	libbz2-dev \
 	' \
 	&& apt-get update \
 	&& apt-get install -y $buildDeps --no-install-recommends \


### PR DESCRIPTION
Added `libbz2-dev` in build dependencies to fix `ImportError` for module `bz2`.