### PR TITLE
Upgrade python 2.7

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,11 +1,16 @@
 FROM metabrainz/consul-template-base:v0.16
 
+# This Dockerfile is based on
+# https://github.com/docker-library/python/blob/master/2.7/wheezy/Dockerfile
+
 # Ensure that local Python build is preferred over whatever might come with the base image
 ENV PATH /usr/local/bin:$PATH
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
+# https://github.com/docker-library/python/issues/147
+ENV PYTHONIOENCODING UTF-8
 
 # Runtime dependencies
 RUN apt-get update \
@@ -18,6 +23,8 @@ ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.12
 ENV PYTHON_PIP_VERSION 9.0.1
 
+# We do this in a single RUN command so that we install the build dependencies
+# and remove them in a single layer so that we don't use as much disk space
 RUN set -ex \
 	# Installing build dependencies
 	&& buildDeps=' \
@@ -29,43 +36,57 @@ RUN set -ex \
 	' \
 	&& apt-get update \
 	&& apt-get install -y $buildDeps --no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
-
-# Building Python
-RUN wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	\
+	# Build python
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
-	&& rm -r "$GNUPGHOME" python.tar.xz.asc \
+	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
 	&& mkdir -p /usr/src/python \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
+	\
 	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-shared \
 		--enable-unicode=ucs4 \
-	&& make -j$(nproc) \
+	&& make -j "$(nproc)" \
 	&& make install \
-	&& ldconfig
+	&& ldconfig \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' + \
+	&& cd /root \
+	&& rm -rf /usr/src/python \
+	\
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Installing pip
-RUN if [ ! -e /usr/local/bin/pip ]; then : \
-		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-		&& python /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-		&& rm /tmp/get-pip.py \
-	; fi \
-	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-	# then we use "pip list" to ensure we don't have more than one pip version installed
-	# https://github.com/docker-library/python/pull/100
-	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
-
-# Cleanup
-RUN find /usr/local -depth \
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
 		\( \
-			\( -type d -a -name test -o -name tests \) \
+			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-		\) -exec rm -rf '{}' + \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -33,6 +33,8 @@ RUN set -ex \
 		tcl-dev \
 		tk-dev \
 		libbz2-dev \
+		libreadline6-dev \
+		libsqlite3-dev \
 	' \
 	&& apt-get update \
 	&& apt-get install -y $buildDeps --no-install-recommends \

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -20,8 +20,8 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
-ENV PYTHON_VERSION 2.7.12
-ENV PYTHON_PIP_VERSION 9.0.1
+ENV PYTHON_VERSION 2.7.15
+ENV PYTHON_PIP_VERSION 19.0.1
 
 # We do this in a single RUN command so that we install the build dependencies
 # and remove them in a single layer so that we don't use as much disk space

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/consul-template-base:v0.16
+FROM metabrainz/consul-template-base:v0.19.4
 
 # This Dockerfile is based on
 # https://github.com/docker-library/python/blob/master/2.7/wheezy/Dockerfile


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/OTHER-338

This performs a number of upgrades to the python 2.7 base image:

* Update the installation process as copied from the official python base image installer at https://github.com/docker-library/python/blob/408f7b813/2.7/wheezy/Dockerfile
* Reduce the number of layers that we create, resulting in a 200MB reduction in disk space used by the image
* Upgrade to the latest version of python 2.7
* Upgrade to the latest consul-template-base image
* Add readline and sqlite support for a better ipython experience