### PR TITLE
Upgrade python 3.6

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,5 +1,8 @@
 FROM metabrainz/consul-template-base:v0.16
 
+# This Dockerfile is based on
+# https://github.com/docker-library/python/blob/master/3.6/wheezy/Dockerfile
+
 # Ensure that local Python build is preferred over whatever might come with the base image
 ENV PATH /usr/local/bin:$PATH
 
@@ -7,59 +10,88 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-# Runtime dependencies
+# Runtime dependencies. This includes the core packages for all of the buildDeps listed
+# below. We explicitly install them so that when we `remove --auto-remove` the dev packages,
+# these packages stay installed.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+                       libbz2-1.0 \
+                       libexpat1 \
+                       libffi6 \
+                       libgdbm3 \
+                       liblzma5 \
+                       libncursesw5 \
+                       libreadline6 \
+                       libsqlite3-0 \
+                       libssl1.0.0 \
                        tcl \
                        tk \
+                       zlib1g \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.6.3
 
+# The list of build dependencies comes from the python-docker slim version:
+# https://github.com/docker-library/python/blob/408f7b8130/3.6/stretch/slim/Dockerfile#L29
 RUN set -ex \
-    # Installing build dependencies
 	&& buildDeps=' \
 		build-essential \
-		libssl-dev \
-		tcl-dev \
-		tk-dev \
 		libbz2-dev \
+		libexpat1-dev \
+		libffi-dev \
+		libgdbm-dev \
+		liblzma-dev \
+		libncursesw5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		tk-dev \
+		tcl-dev \
+		xz-utils \
+		zlib1g-dev \
 	' \
 	&& apt-get update \
 	&& apt-get install -y $buildDeps --no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
-
-# Building Python
-RUN wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+    \
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
-	&& rm -r "$GNUPGHOME" python.tar.xz.asc \
+	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
 	&& mkdir -p /usr/src/python \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \
+	\
 	&& cd /usr/src/python \
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
 		--without-ensurepip \
 	&& make -j "$(nproc)" \
 	&& make install \
-	&& ldconfig
-
-# Cleanup
-RUN find /usr/local -depth \
+	&& ldconfig \
+	\
+	&& find /usr/local -depth \
 		\( \
-			\( -type d -a -name test -o -name tests \) \
+			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python \
+
+	\
 	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /usr/src/python ~/.cache
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& python3 --version
+
 
 # Make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
@@ -84,9 +116,8 @@ RUN set -ex; \
 	\
 	find /usr/local -depth \
 		\( \
-			\( -type d -a -name test -o -name tests \) \
+			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
-			\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +; \
-
 	rm -f get-pip.py

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.6.3
+ENV PYTHON_VERSION 3.6.8
 
 # The list of build dependencies comes from the python-docker slim version:
 # https://github.com/docker-library/python/blob/408f7b8130/3.6/stretch/slim/Dockerfile#L29
@@ -101,8 +101,9 @@ RUN cd /usr/local/bin \
 	&& ln -s python3 python \
 	&& ln -s python3-config python-config
 
-# Installing pip
-ENV PYTHON_PIP_VERSION 9.0.1
+# Install pip
+ENV PYTHON_PIP_VERSION 19.0.1
+
 RUN set -ex; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/consul-template-base:v0.16
+FROM metabrainz/consul-template-base:v0.19.4
 
 # This Dockerfile is based on
 # https://github.com/docker-library/python/blob/master/3.6/wheezy/Dockerfile


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/OTHER-338

Like #3, but performs a number of upgrades to the python 3.6 base image:

* Update the insallation process as copied from the official python base image installer at https://github.com/docker-library/python/blob/408f7b813/3.6/stretch/Dockerfile
* Add all of the build dependencies listed in https://github.com/docker-library/python/blob/408f7b813/3.6/stretch/slim/Dockerfile#L28 so that all optional python extensions are compiled
* Reduce the number of layers that we create, resulting in a 400MB reduction in disk space used by the image
* Upgrade to the latest version of python 3.6
* Upgrade to the latest consul-template-base image