### PR TITLE
Add python 3.7

### DIFF
--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -1,0 +1,126 @@
+FROM metabrainz/consul-template-base:v0.19.4
+
+# This Dockerfile is based on
+# https://github.com/docker-library/python/blob/master/3.7/wheezy/Dockerfile
+
+# Ensure that local Python build is preferred over whatever might come with the base image
+ENV PATH /usr/local/bin:$PATH
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+# Runtime dependencies. This includes the core packages for all of the buildDeps listed
+# below. We explicitly install them so that when we `remove --auto-remove` the dev packages,
+# these packages stay installed.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+                       ca-certificates \
+                       netbase \
+                       libbz2-1.0 \
+                       libexpat1 \
+                       libffi6 \
+                       libgdbm3 \
+                       liblzma5 \
+                       libncursesw5 \
+                       libreadline6 \
+                       libsqlite3-0 \
+                       libssl1.0.0 \
+                       libuuid1 \
+                       tcl \
+                       tk \
+                       zlib1g \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+ENV PYTHON_VERSION 3.7.2
+
+# The list of build dependencies comes from the python-docker slim version:
+# https://github.com/docker-library/python/blob/408f7b8130/3.7/stretch/slim/Dockerfile#L29
+RUN set -ex \
+	&& buildDeps=' \
+		build-essential \
+		libbz2-dev \
+		libexpat1-dev \
+		libffi-dev \
+		libgdbm-dev \
+		liblzma-dev \
+		libncursesw5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		tk-dev \
+		tcl-dev \
+		uuid-dev \
+		xz-utils \
+		zlib1g-dev \
+	' \
+	&& apt-get update \
+	&& apt-get install -y $buildDeps --no-install-recommends \
+    \
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+	&& make install \
+	&& ldconfig \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python \
+	\
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& python3 --version
+
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+	&& ln -s idle3 idle \
+	&& ln -s pydoc3 pydoc \
+	&& ln -s python3 python \
+	&& ln -s python3-config python-config
+
+# Install pip
+ENV PYTHON_PIP_VERSION 19.0.1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py

--- a/push.sh
+++ b/push.sh
@@ -3,7 +3,7 @@
 # Build all Python images image from the currently checked out version and
 # push them it to the Docker Hub.
 
-for version in 2.7 3.6
+for version in 2.7 3.6 3.7
 do
 	pushd "$(dirname "${BASH_SOURCE[0]}")/${version}/"
 	echo "Building ${version}..."


### PR DESCRIPTION
Based on the official docker python image at
https://github.com/docker-library/python/blob/408f7b813/3.7/stretch/Dockerfile
in the same format as the existing metabrainz 3.6 image