### PR TITLE
Use creation date for tagging and pushing Docker images

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -85,7 +85,6 @@ RUN set -ex \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
 	&& rm -rf /usr/src/python \
-
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ need to use Consul Template, that service needs to be removed explicitly in the 
 writing.
 
 Configuration for it must be stored in the */etc/consul-template.conf* file. See its
-[documentation](ttps://github.com/hashicorp/consul-template) for setup details.
+[documentation](https://github.com/hashicorp/consul-template) for setup details.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Configuration for it must be stored in the */etc/consul-template.conf* file. See
 ## Usage
 
 To use these images simply specify `FROM metabrainz/python:<TAG>` at the beginning of your Dockerfile.
-`<TAG>` is a version of Python that you need to use. List of available tags is at https://hub.docker.com/r/metabrainz/python/tags/.
+`<TAG>` is a *version of Python* that you need to use, followed with the *creation date* of the image;
+If an image is updated more than once in a day, then extra tags will also include the sequence number.
+See the [list of image tags available on Docker Hub|https://hub.docker.com/r/metabrainz/python/tags/].
 
 ## Building and deploying images
 
-Use `push.sh` script.
+Use [`push.sh`](push.sh) script.  The way it operates is detailed in its heading comments.

--- a/push.sh
+++ b/push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build all Python images image from the currently checked out version and
 # push them it to the Docker Hub.

--- a/push.sh
+++ b/push.sh
@@ -5,13 +5,15 @@
 
 set -e -o pipefail -u
 
+DOCKER_CMD=${DOCKER_CMD:-docker}
+
 for version in 2.7 3.6 3.7 3.8
 do
 	pushd "$(dirname "${BASH_SOURCE[0]}")/${version}/"
 	echo "Building ${version}..."
-	docker build -t metabrainz/python:${version} .
+	${DOCKER_CMD} build -t metabrainz/python:${version} .
 	echo "Pushing ${version}..."
-	docker push metabrainz/python:${version}
+	${DOCKER_CMD} push metabrainz/python:${version}
 	popd
 done
 

--- a/push.sh
+++ b/push.sh
@@ -5,15 +5,17 @@
 
 set -e -o pipefail -u
 
+image_name='metabrainz/python'
+
 DOCKER_CMD=${DOCKER_CMD:-docker}
 
 for version in 2.7 3.6 3.7 3.8
 do
 	pushd "$(dirname "${BASH_SOURCE[0]}")/${version}/"
 	echo "Building ${version}..."
-	${DOCKER_CMD} build -t metabrainz/python:${version} .
+	${DOCKER_CMD} build -t ${image_name}:${version} .
 	echo "Pushing ${version}..."
-	${DOCKER_CMD} push metabrainz/python:${version}
+	${DOCKER_CMD} push ${image_name}:${version}
 	popd
 done
 

--- a/push.sh
+++ b/push.sh
@@ -3,6 +3,8 @@
 # Build all Python images image from the currently checked out version and
 # push them it to the Docker Hub.
 
+set -e -o pipefail -u
+
 for version in 2.7 3.6 3.7 3.8
 do
 	pushd "$(dirname "${BASH_SOURCE[0]}")/${version}/"

--- a/push.sh
+++ b/push.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 #
-# Build all Python images image from the currently checked out version and
-# push them it to the Docker Hub.
+# Build Docker images for each Python version `x.y`;
+# Tag them `x.y` and `x.y-date`;
+# Add `x.y-date.sequence` tags if built more than once in a day;
+# Finally, push them to Docker Hub.
+#
+# This script is purposed for maintainers only, not contributors.
+#
+# Usage:
+#   $ ./push.sh
 
 set -e -o pipefail -u
 
@@ -9,11 +16,59 @@ image_name='metabrainz/python'
 
 DOCKER_CMD=${DOCKER_CMD:-docker}
 
+for cmd in grep jq sed wget
+do
+	if ! type "${cmd}" &>/dev/null
+	then
+		echo >&2 "Error: ${cmd}: command not found"
+		exit 69 # EX_UNAVAILABLE
+	fi
+done
+
+# shellcheck disable=SC2207
+remote_tags=($(wget -q \
+	https://registry.hub.docker.com/v1/repositories/${image_name}/tags \
+	-O - | jq -r '.[] | .name'))
+
 for version in 2.7 3.6 3.7 3.8
 do
 	pushd "$(dirname "${BASH_SOURCE[0]}")/${version}/"
 	echo "Building ${version}..."
 	${DOCKER_CMD} build -t ${image_name}:${version} .
+	created=$(${DOCKER_CMD} inspect -f '{{.Created}}' ${image_name}:${version} \
+		| sed 's/^\(....\)-\(..\)-\(..\)T.*$/\1\2\3/')
+	date_version=${version}-${created}
+	if [[ " ${remote_tags[*]} " == *" ${date_version} "* ]]
+	then
+		tags_count=$(printf '%s\n' "${remote_tags[@]}" | grep -c -F "${date_version}")
+		if [[ ${tags_count} -eq 1 ]]
+		then
+			backup_version=${date_version}.0
+			echo "Backing up previous ${date_version} as ${backup_version}..."
+			if [[ " ${remote_tags[*]} " == *" ${backup_version} "* ]]
+			then
+				echo >&2 "Error: Backup tag ${backup_version} already exists"
+				exit 70 # EX_SOFTWARE
+			fi
+			${DOCKER_CMD} pull "${image_name}:${date_version}"
+			${DOCKER_CMD} tag "${image_name}:${date_version}" "${image_name}:${backup_version}"
+			${DOCKER_CMD} push "${image_name}:${backup_version}"
+			remote_tags+=("${backup_version}")
+		fi
+		sequence=$(printf '%s\n' "${remote_tags[@]}" | grep -c -F "${date_version}.")
+		sequence_version=${version}-${created}.${sequence}
+		if [[ " ${remote_tags[*]} " == *" ${sequence_version} "* ]]
+		then
+			echo >&2 "Error: Sequence tag ${sequence_version} already exists"
+			exit 70 # EX_SOFTWARE
+		fi
+		${DOCKER_CMD} tag "${image_name}:${version}" "${image_name}:${sequence_version}"
+		echo "Pushing ${sequence_version}..."
+		${DOCKER_CMD} push "${image_name}:${sequence_version}"
+	fi
+	${DOCKER_CMD} tag "${image_name}:${version}" "${image_name}:${date_version}"
+	echo "Pushing ${date_version}..."
+	${DOCKER_CMD} push "${image_name}:${date_version}"
 	echo "Pushing ${version}..."
 	${DOCKER_CMD} push ${image_name}:${version}
 	popd


### PR DESCRIPTION
# Problem

Breaking changes may occur when updating Python base images.

# Solution

As proposed by @alastair and @mayhem (see https://github.com/metabrainz/docker-python/pull/8#pullrequestreview-526269352 and [example](https://chatlogs.metabrainz.org/brainzbot/metabrainz/msg/4698725/)), a new tagging scheme with creation date would allow to keep using older base images until all dependent repositories have been updated.

New tags with creation date have already been added for current images, see https://hub.docker.com/r/metabrainz/python/tags

This pull request makes `push.sh` to add a tag with creation date. It also handles the case when two images have been pushed on the same day. See commit https://github.com/metabrainz/docker-python/commit/6dd85a8aeb96789790ae3760c8f87ee584c742b1 for details.