### PR TITLE
Python 3.9 image

### DIFF
--- a/3.9/Dockerfile
+++ b/3.9/Dockerfile
@@ -36,7 +36,7 @@ ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
 ENV PYTHON_VERSION 3.9.1
 
 # The list of build dependencies comes from the python-docker slim version:
-# https://github.com/docker-library/python/blob/32b69d61f6/3.8/buster/slim/Dockerfile#L29
+# https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/slim/Dockerfile#L33
 RUN set -ex \
 	&& buildDeps=' \
 		build-essential \

--- a/3.9/Dockerfile
+++ b/3.9/Dockerfile
@@ -1,0 +1,132 @@
+FROM metabrainz/consul-template-base:v0.18.5-2
+
+# This Dockerfile is based on
+# https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/Dockerfile
+
+# Ensure that local Python build is preferred over whatever might come with the base image
+ENV PATH /usr/local/bin:$PATH
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+# Runtime dependencies. This includes the core packages for all of the buildDeps listed
+# below. We explicitly install them so that when we `remove --auto-remove` the dev packages,
+# these packages stay installed.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+                       ca-certificates \
+                       netbase \
+                       libbz2-1.0 \
+                       libexpat1 \
+                       libffi6 \
+                       libgdbm3 \
+                       liblzma5 \
+                       libncursesw5 \
+                       libreadline6 \
+                       libsqlite3-0 \
+                       libssl1.0.0 \
+                       libuuid1 \
+                       tcl \
+                       tk \
+                       zlib1g \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
+ENV PYTHON_VERSION 3.9.1
+
+# The list of build dependencies comes from the python-docker slim version:
+# https://github.com/docker-library/python/blob/32b69d61f6/3.8/buster/slim/Dockerfile#L29
+RUN set -ex \
+	&& buildDeps=' \
+		build-essential \
+		libbz2-dev \
+		libexpat1-dev \
+		libffi-dev \
+		libgdbm-dev \
+		liblzma-dev \
+		libncursesw5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		tk-dev \
+		tcl-dev \
+		uuid-dev \
+		xz-utils \
+		zlib1g-dev \
+	' \
+	&& apt-get update \
+	&& apt-get install -y $buildDeps --no-install-recommends \
+    \
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-optimizations \
+		--enable-option-checking=fatal \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+	&& make install \
+	&& rm -rf /usr/src/python \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+		\) -exec rm -rf '{}' + \
+	\
+	&& ldconfig \
+	\
+	&& python3 --version
+
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+	&& ln -s idle3 idle \
+	&& ln -s pydoc3 pydoc \
+	&& ln -s python3 python \
+	&& ln -s python3-config python-config
+
+# Install pip
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 20.3.3
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/39356a9d34700a468cf847867ac1a3bd72cc5e45/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 ec367c5c9b82fa13c04cfabb0a069e84496d5c36714f14d19b5f24d519d3ba25
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
+
+CMD ["python3"]

--- a/README.md
+++ b/README.md
@@ -8,12 +8,17 @@ This repository contains Docker images with different versions of Python install
 
 ### Consul Template
 
-Consul Template runs as a separate service managed by *runit*, and is **turned on by default**. If you don't
+Consul Template runs as a separate service managed by *runit*.
+
+With Consul Template 0.16, Configuration for it must be stored in the */etc/consul-template.conf* file. See its
+[documentation](https://github.com/hashicorp/consul-template) for setup details.
+Consul Template is **turned on by default**. If you don't
 need to use Consul Template, that service needs to be removed explicitly in the Dockerfile that you are
 writing.
 
-Configuration for it must be stored in the */etc/consul-template.conf* file. See its
-[documentation](https://github.com/hashicorp/consul-template) for setup details.
+With Consul Template 0.18, you must create your own runit service and use the `run-consul-template`
+script to render a template and execute a child process. See an 
+[example in the MusicBrainz server](https://github.com/metabrainz/musicbrainz-server/tree/master/docker/musicbrainz-website).
 
 ## Usage
 
@@ -25,3 +30,16 @@ See the [list of image tags available on Docker Hub|https://hub.docker.com/r/met
 ## Building and deploying images
 
 Use [`push.sh`](push.sh) script.  The way it operates is detailed in its heading comments.
+
+## Available images
+
+We have these images available:
+
+image version | python version | consul-template version
+----|----|----
+2.7, 2.7-20201201 | 2.7.18 | 0.16
+3.6-1 | 3.6.8 | 0.18
+3.6, 3.6-20201201 | 3.6.12 | 0.16
+3.7, 3.7-20201201 | 3.7.9 | 0.16
+3.8, 3.8-20201201 | 3.8.6 | 0.16
+3.9, 3.9-20210115 | 3.9.1 | 0.18

--- a/push.sh
+++ b/push.sh
@@ -30,7 +30,7 @@ remote_tags=($(wget -q \
 	https://registry.hub.docker.com/v1/repositories/${image_name}/tags \
 	-O - | jq -r '.[] | .name'))
 
-for version in 2.7 3.6 3.7 3.8
+for version in 2.7 3.6 3.7 3.8 3.9
 do
 	pushd "$(dirname "${BASH_SOURCE[0]}")/${version}/"
 	echo "Building ${version}..."


### PR DESCRIPTION
Note that this image is based on `metabrainz/consul-template-base:v0.18.5-2`, not `v0.16` like the other python versions.