### PR TITLE
Upgrade images to use consul-template 0.18.5

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/consul-template-base:v0.16
+FROM metabrainz/consul-template-base:v0.18.5-2
 
 # This Dockerfile is based on
 # https://github.com/docker-library/python/blob/master/2.7/wheezy/Dockerfile

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/consul-template-base:v0.16
+FROM metabrainz/consul-template-base:v0.18.5-2
 
 # This Dockerfile is based on
 # https://github.com/docker-library/python/blob/master/3.6/wheezy/Dockerfile

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/consul-template-base:v0.16
+FROM metabrainz/consul-template-base:v0.18.5-2
 
 # This Dockerfile is based on
 # https://github.com/docker-library/python/blob/master/3.7/wheezy/Dockerfile

--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/consul-template-base:v0.16
+FROM metabrainz/consul-template-base:v0.18.5-2
 
 # This Dockerfile is based on
 # https://github.com/docker-library/python/blob/32b69d61f6/3.8/buster/Dockerfile


### PR DESCRIPTION
With the plans to upgrade to new consul, we need new base images running consul-template 0.18 so that we can update the startup scripts for all python apps.

We will still have the `-20201201` variations of the images which run consul-template 0.15.