### PR TITLE
Add a 3.9-focal Dockerfile

### DIFF
--- a/3.9-focal/Dockerfile
+++ b/3.9-focal/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
-ENV PYTHON_VERSION 3.9.7
+ENV PYTHON_VERSION 3.9.10
 
 # The list of build dependencies comes from the python-docker slim version:
 # https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/slim/Dockerfile#L33
@@ -104,7 +104,7 @@ RUN cd /usr/local/bin \
 
 # Install pip
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 21.2.4
+ENV PYTHON_PIP_VERSION 22.0.4
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/39356a9d34700a468cf847867ac1a3bd72cc5e45/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 ec367c5c9b82fa13c04cfabb0a069e84496d5c36714f14d19b5f24d519d3ba25

--- a/3.9-focal/Dockerfile
+++ b/3.9-focal/Dockerfile
@@ -1,0 +1,130 @@
+FROM metabrainz/consul-template-base:focal-1.1.0_ct_0.27.1
+
+# This Dockerfile is based on
+# https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/Dockerfile
+
+# Ensure that local Python build is preferred over whatever might come with the base image
+ENV PATH /usr/local/bin:$PATH
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+# Runtime dependencies. This includes the core packages for all of the buildDeps listed
+# below. We explicitly install them so that when we `remove --auto-remove` the dev packages,
+# these packages stay installed.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+                       ca-certificates \
+                       netbase \
+                       libbz2-1.0 \
+                       libexpat1 \
+                       libffi7 \
+                       libgdbm6 \
+                       liblzma5 \
+                       libncursesw5 \
+                       libreadline8 \
+                       libsqlite3-0 \
+                       libssl1.1 \
+                       libuuid1 \
+                       tcl \
+                       tk \
+                       zlib1g \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
+ENV PYTHON_VERSION 3.9.7
+
+# The list of build dependencies comes from the python-docker slim version:
+# https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/slim/Dockerfile#L33
+RUN set -ex \
+	&& buildDeps=' \
+		build-essential \
+		libbz2-dev \
+		libexpat1-dev \
+		libffi-dev \
+		libgdbm-dev \
+		liblzma-dev \
+		libncursesw5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		tk-dev \
+		tcl-dev \
+		uuid-dev \
+		xz-utils \
+		zlib1g-dev \
+	' \
+	&& apt-get update \
+	&& apt-get install -y $buildDeps --no-install-recommends \
+    \
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY" \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-optimizations \
+		--enable-option-checking=fatal \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+	&& make install \
+	&& rm -rf /usr/src/python \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+		\) -exec rm -rf '{}' + \
+	\
+	&& ldconfig \
+	\
+	&& python3 --version
+
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+	&& ln -s idle3 idle \
+	&& ln -s pydoc3 pydoc \
+	&& ln -s python3 python \
+	&& ln -s python3-config python-config
+
+# Install pip
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 21.2.4
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/39356a9d34700a468cf847867ac1a3bd72cc5e45/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 ec367c5c9b82fa13c04cfabb0a069e84496d5c36714f14d19b5f24d519d3ba25
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py

--- a/3.9/Dockerfile
+++ b/3.9/Dockerfile
@@ -3,6 +3,13 @@ FROM metabrainz/consul-template-base:v0.18.5-2
 # This Dockerfile is based on
 # https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/Dockerfile
 
+# remove expired let's encrypt certificate and install new ones
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 # Ensure that local Python build is preferred over whatever might come with the base image
 ENV PATH /usr/local/bin:$PATH
 
@@ -16,6 +23,7 @@ ENV LANG C.UTF-8
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
                        ca-certificates \
+                       gnupg-curl \
                        netbase \
                        libbz2-1.0 \
                        libexpat1 \
@@ -33,7 +41,7 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
-ENV PYTHON_VERSION 3.9.5
+ENV PYTHON_VERSION 3.9.10
 
 # The list of build dependencies comes from the python-docker slim version:
 # https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/slim/Dockerfile#L33
@@ -61,7 +69,7 @@ RUN set -ex \
 	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY" \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
 	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
 	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
@@ -104,7 +112,7 @@ RUN cd /usr/local/bin \
 
 # Install pip
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.3
+ENV PYTHON_PIP_VERSION 22.0.4
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/39356a9d34700a468cf847867ac1a3bd72cc5e45/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 ec367c5c9b82fa13c04cfabb0a069e84496d5c36714f14d19b5f24d519d3ba25

--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ image version | python version | consul-template version | ubuntu version
 3.7, 3.7-20210115 | 3.7.9 | 0.18 | bionic
 3.8-20201201 | 3.8.6 | 0.16 | bionic
 3.8, 3.8-20210115 | 3.8.6 | 0.18 | bionic
-3.9, 3.9-20210514 | 3.9.5 | 0.18 | bionic
-3.9-focal-20211007 | 3.9.7 | 0.27.1 | focal
+3.9, 3.9-20220315 | 3.9.10 | 0.18 | bionic
+3.9-focal, 3.9-focal-20220315 | 3.9.10 | 0.27.1 | focal

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ Use [`push.sh`](push.sh) script.  The way it operates is detailed in its heading
 
 We have these images available:
 
-image version | python version | consul-template version
-----|----|----
-2.7-20201201 | 2.7.18 | 0.16
-2.7, 2.7-20210115 | 2.7.18 | 0.18
-3.7-20201201 | 3.7.9 | 0.16
-3.7, 3.7-20210115 | 3.7.9 | 0.18
-3.8-20201201 | 3.8.6 | 0.16
-3.8, 3.8-20210115 | 3.8.6 | 0.18
-3.9, 3.9-20210514 | 3.9.5 | 0.18
+image version | python version | consul-template version | ubuntu version
+----|----|----|----
+2.7-20201201 | 2.7.18 | 0.16 | bionic
+2.7, 2.7-20210115 | 2.7.18 | 0.18 | bionic
+3.7-20201201 | 3.7.9 | 0.16 | bionic
+3.7, 3.7-20210115 | 3.7.9 | 0.18 | bionic
+3.8-20201201 | 3.8.6 | 0.16 | bionic
+3.8, 3.8-20210115 | 3.8.6 | 0.18 | bionic
+3.9, 3.9-20210514 | 3.9.5 | 0.18 | bionic
+3.9-focal-20211007 | 3.9.7 | 0.27.1 | focal

--- a/push.sh
+++ b/push.sh
@@ -30,7 +30,7 @@ remote_tags=($(wget -q \
 	https://registry.hub.docker.com/v1/repositories/${image_name}/tags \
 	-O - | jq -r '.[] | .name'))
 
-for version in 2.7 3.7 3.8 3.9
+for version in 2.7 3.7 3.8 3.9 '3.9-focal'
 do
 	pushd "$(dirname "${BASH_SOURCE[0]}")/${version}/"
 	echo "Building ${version}..."


### PR DESCRIPTION
This is copied from the 3.9/Dockerfile, with a few changes:

 * It's based on the newer focal base image with consul-template 0.27.1.
 * Some apt package names have been fixed to reflect what focal uses.
 * PYTHON_VERSION has been bumped to 3.9.7.
 * PYTHON_PIP_VERSION has been bumped to 21.2.4.
 * The keyserver has been updated to use what https://github.com/docker-library/python/blob/master/3.9/buster/Dockerfile has. I was getting "gpg: keyserver receive failed: No name" with the old one.

Diff:

```diff
-FROM metabrainz/consul-template-base:v0.18.5-2
+FROM metabrainz/consul-template-base:focal-1.1.0_ct_0.27.1
 
 # This Dockerfile is based on
 # https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/Dockerfile
@@ -19,13 +19,13 @@
                        netbase \
                        libbz2-1.0 \
                        libexpat1 \
-                       libffi6 \
-                       libgdbm3 \
+                       libffi7 \
+                       libgdbm6 \
                        liblzma5 \
                        libncursesw5 \
-                       libreadline6 \
+                       libreadline8 \
                        libsqlite3-0 \
-                       libssl1.0.0 \
+                       libssl1.1 \
                        libuuid1 \
                        tcl \
                        tk \
@@ -33,7 +33,7 @@
        && rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
-ENV PYTHON_VERSION 3.9.5
+ENV PYTHON_VERSION 3.9.7
 
 # The list of build dependencies comes from the python-docker slim version:
 # https://github.com/docker-library/python/blob/393ba9b3/3.9/buster/slim/Dockerfile#L33
@@ -61,7 +61,7 @@
        && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
        && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
        && export GNUPGHOME="$(mktemp -d)" \
-       && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+       && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY" \
        && gpg --batch --verify python.tar.xz.asc python.tar.xz \
        && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
        && rm -rf "$GNUPGHOME" python.tar.xz.asc \
@@ -104,7 +104,7 @@
 
 # Install pip
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.3
+ENV PYTHON_PIP_VERSION 21.2.4
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/39356a9d34700a468cf847867ac1a3bd72cc5e45/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 ec367c5c9b82fa13c04cfabb0a069e84496d5c36714f14d19b5f24d519d3ba25

```