### PR TITLE
Update 2.7 image with focal base image

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,7 +1,10 @@
-FROM metabrainz/consul-template-base:v0.18.5-2
+FROM metabrainz/consul-template-base:focal-1.1.0_ct_0.27.1
 
 # This Dockerfile is based on
-# https://github.com/docker-library/python/blob/master/2.7/wheezy/Dockerfile
+# https://github.com/docker-library/python/blob/a33fcb6adc834c2fdddd894fd0bbfc2609488e69/2.7/wheezy/Dockerfile
+# https://github.com/docker-library/python/blob/f1e613f48eb4fc88748b36787f5ed74c14914636/2.7/buster/Dockerfile
+# and
+# https://github.com/docker-library/python/blob/652ed14d33da62558f336047bf0f6ea45addb596/3.10/bullseye/slim/Dockerfile
 
 # Ensure that local Python build is preferred over whatever might come with the base image
 ENV PATH /usr/local/bin:$PATH
@@ -12,16 +15,21 @@ ENV LANG C.UTF-8
 # https://github.com/docker-library/python/issues/147
 ENV PYTHONIOENCODING UTF-8
 
-# Runtime dependencies
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-					   tcl \
-					   tk \
-	&& rm -rf /var/lib/apt/lists/*
+# runtime dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		netbase \
+		tcl \
+		tk \
+		tzdata \
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
 ENV PYTHON_VERSION 2.7.18
-ENV PYTHON_PIP_VERSION 20.2.3
+ENV PYTHON_PIP_VERSION 20.3.4
 
 # We do this in a single RUN command so that we install the build dependencies
 # and remove them in a single layer so that we don't use as much disk space
@@ -33,7 +41,7 @@ RUN set -ex \
 		tcl-dev \
 		tk-dev \
 		libbz2-dev \
-		libreadline6-dev \
+		libreadline-dev \
 		libsqlite3-dev \
 	' \
 	&& apt-get update \
@@ -43,7 +51,7 @@ RUN set -ex \
 	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY" \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
 	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
 	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
@@ -52,18 +60,56 @@ RUN set -ex \
 	&& rm python.tar.xz \
 	\
 	&& cd /usr/src/python \
-	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \
+		--enable-optimizations \
+		--enable-option-checking=fatal \
 		--enable-shared \
 		--enable-unicode=ucs4 \
+# setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
+		PROFILE_TASK='-m test.regrtest --pgo \
+			test_array \
+			test_base64 \
+			test_binascii \
+			test_binhex \
+			test_binop \
+			test_bytes \
+			test_c_locale_coercion \
+			test_class \
+			test_cmath \
+			test_codecs \
+			test_compile \
+			test_complex \
+			test_csv \
+			test_decimal \
+			test_dict \
+			test_float \
+			test_fstring \
+			test_hashlib \
+			test_io \
+			test_iter \
+			test_json \
+			test_long \
+			test_math \
+			test_memoryview \
+			test_pickle \
+			test_re \
+			test_set \
+			test_slice \
+			test_struct \
+			test_threading \
+			test_time \
+			test_traceback \
+			test_unicode \
+		' \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig \
 	\
 	&& find /usr/local -depth \
 		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
+			\( -type d -a \( -name test -o -name test -o -name idle_tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' + \
@@ -71,12 +117,15 @@ RUN set -ex \
 	&& rm -rf /usr/src/python \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& python2 --version
 
 # Installing pip
 RUN set -ex; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	wget -O get-pip.py 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'; \
+	echo "40ee07eac6674b8d60fce2bbabc148cf0e2f1408c167683f110fd608b8d6f416 *get-pip.py" | sha256sum --check --strict -; \
 	\
 	python get-pip.py \
 		--disable-pip-version-check \
@@ -87,7 +136,7 @@ RUN set -ex; \
 	\
 	find /usr/local -depth \
 		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
+			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +; \

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ image version | python version | consul-template version | ubuntu version
 ----|----|----|----
 2.7-20201201 | 2.7.18 | 0.16 | bionic
 2.7, 2.7-20210115 | 2.7.18 | 0.18 | bionic
+2.7-20220421 | 2.7.18 | 0.27.1 | focal
 3.7-20201201 | 3.7.9 | 0.16 | bionic
 3.7, 3.7-20210115 | 3.7.9 | 0.18 | bionic
 3.8-20201201 | 3.8.6 | 0.16 | bionic


### PR DESCRIPTION
# Problem

Image had the following warnings at startup:
```log
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/10_syslog-ng.init...
[2022-04-20T11:06:37.728675] WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. Please update it to use the syslog-ng 3.25 format at your time of convenience. To upgrade the configuration, please review the warnings about incompatible changes printed by syslog-ng, and once completed change the @version header at the top of the configuration file; config-version='3.13'
[2022-04-20T11:06:37.929293] WARNING: With use-dns(no), dns-cache() will be forced to 'no' too!;
Apr 20 11:06:37 4c2e5f3adfd6 syslog-ng[14]: syslog-ng starting up; version='3.25.1'
Apr 20 11:06:37 4c2e5f3adfd6 syslog-ng[14]: WARNING: log-fifo-size() works differently starting with syslog-ng 3.22 to avoid dropping flow-controlled messages when log-fifo-size() is misconfigured. From now on, log-fifo-size() only affects messages that are not flow-controlled. (Flow-controlled log paths have the flags(flow-control) option set.) To enable the new behaviour, update the @version string in your configuration and consider lowering the value of log-fifo-size().;
```
Those have been fixed for `3.10` by updating the base image to use a more recent `phusion` image.

# Solution

- Update Ubuntu to focal
- Update Consul Template to 0.27.1
- Update Pip to 20.3.4 (the latest version compatible with Python 2.7)
- Update Readline library to 8

Follow changes made to upstream 2.7 image and to our own 3.10 image:
- Install focal runtime dependencies: ca-certificates, netbase, tzdata
- Improve checking downloads
- Enable optimizations
- Clean idle test

References:
- https://github.com/docker-library/python/blob/a33fcb6adc834c2fdddd894fd0bbfc2609488e69/2.7/wheezy/Dockerfile
- https://github.com/docker-library/python/blob/f1e613f48eb4fc88748b36787f5ed74c14914636/2.7/buster/Dockerfile
- https://github.com/docker-library/python/blob/652ed14d33da62558f336047bf0f6ea45addb596/3.10/bullseye/slim/Dockerfile
- https://github.com/metabrainz/docker-python/blob/bbac1492f8e6eaa67d94bec8337ad62855a3370f/3.10/Dockerfile

# Checklist for author

- [x] Build and publish to Docker Hub
- [x] Test with a local instance of SIR