### PR TITLE
Fix python 3.13 image build

### DIFF
--- a/3.13/Dockerfile
+++ b/3.13/Dockerfile
@@ -124,6 +124,7 @@ RUN set -eux; \
 		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
+		| awk '!/^diversion by/ { print } /^diversion by/ { gsub("^diversion by ", ""); gsub(" from:.*$| to:.*$", ""); print }' \
 		| cut -d: -f1 \
 		| sort -u \
 		| xargs -r apt-mark manual \

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ image version | python version | consul-template version | ubuntu version
 3.11, 3.11-20221221 | 3.11.1 | 0.27.1 | focal
 3.11-20231006 | 3.11.6 | 0.33.0 | jammy
 3.12-20241130 | 3.12.7 | 0.39.1 | jammy
-3.13-20240310 | 3.13.2 | 0.40.0 | noble
+3.13-20240313 | 3.13.2 | 0.40.0 | noble


### PR DESCRIPTION
The abridged output for `dpkg-query --search` for the image looks like this:

```
libncursesw6:amd64: /usr/lib/x86_64-linux-gnu/libncursesw.so.6
libncursesw6:amd64: /usr/lib/x86_64-linux-gnu/libpanelw.so.6
diversion by libreadline8t64 from: /lib/x86_64-linux-gnu/libreadline.so.8
diversion by libreadline8t64 to: /lib/x86_64-linux-gnu/libreadline.so.8.usr-is-merged
libreadline8t64:amd64: /usr/lib/x86_64-linux-gnu/libreadline.so.8
libsqlite3-0:amd64: /usr/lib/x86_64-linux-gnu/libsqlite3.so.0
```

In the absence of the newly added `awk` in the pipeline, one of the inputs received by the last `xargs -r apt-mark manual` contains `diversion by libreadline8t64 to`. This fails because there is no package named diversion, by, from, or to. To fix this issue add another `awk` step to the pipeline to remove the words `diversion by` from the start of the line and `from:`, `to:` from `dpkg-query`'s output.